### PR TITLE
feat(logs): log level filtering, regex search, and power features

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ A Node.js TUI for inspecting and monitoring Kubernetes clusters in real-time.
 - Loading spinner and scroll progress indicator
 - Context-aware footer hints that change based on active view
 
+### Pod Log Features
+
+- **Log level filtering** — cycle through ALL / ERROR / WARN / INFO with `l`; lines are color-coded (red / yellow / cyan) regardless of active filter
+- **Regex search** — toggle regex mode with `r` before or during `/` search; invalid patterns degrade gracefully
+- **Timestamp toggle** — `t` shows or hides the RFC3339 timestamp prefix without restarting the stream
+- **Line wrap toggle** — `w` switches between truncate and full-wrap mode
+- **Tail size control** — `+` / `-` cycles the initial fetch window (50 / 100 / 200 / 500 lines)
+- **Since filter** — `s` cycles recency filters: all / last 5 m / 15 m / 1 h
+- **Previous container logs** — `p` streams logs from the last-terminated container instance (crash-loop debugging)
+- **Dynamic height** — log panes in multi-pod view expand to fill the terminal rather than using a fixed line count
+
 ## Requirements
 
 - Node.js 20+
@@ -48,6 +59,34 @@ npm start -- --enable-mutations --max-replicas=10
 | `c`            | Switch kubeconfig context            |
 | `Esc`          | Dismiss alert / close detail / clear search |
 | `q` / `Ctrl+C` | Quit                                 |
+
+### Pod Log View
+
+| Key         | Action                                                   |
+| ----------- | -------------------------------------------------------- |
+| `↑` / `↓`  | Scroll log                                               |
+| `g` / `G`  | Jump to top / bottom                                     |
+| `f`         | Toggle follow mode                                       |
+| `/`         | Search log lines                                         |
+| `r`         | Toggle regex search mode                                 |
+| `l`         | Cycle log level filter (ALL → ERROR → WARN → INFO)       |
+| `t`         | Toggle timestamp display                                 |
+| `w`         | Toggle line wrap                                         |
+| `s`         | Cycle since filter (all → 5 m → 15 m → 1 h)             |
+| `p`         | Toggle previous container logs (crash-loop debugging)    |
+| `+` / `-`   | Increase / decrease initial tail size (50/100/200/500)   |
+| `[` / `]`  | Switch active container                                  |
+| `m`         | Toggle split-pane view (multi-container pods)            |
+| `Esc`       | Close detail view                                        |
+
+### Multi-pod Log View
+
+| Key              | Action                                    |
+| ---------------- | ----------------------------------------- |
+| `←` / `→` / `h` / `l` | Move focus between pod panes        |
+| `↑` / `↓`        | Scroll focused pane                       |
+| `L` (Shift+L)    | Cycle log level filter across all panes   |
+| `Esc`            | Return to resource table                  |
 
 ### Mutations (requires `--enable-mutations`)
 
@@ -84,7 +123,7 @@ src/
 ├── hooks/
 │   ├── useKubeClient.ts   # Loads kubeconfig, exposes context switching
 │   ├── useResources.ts    # Watch-based live resource state (reconnects on disconnect)
-│   ├── useLogStream.ts    # Streams pod logs into a ring buffer (last 500 lines)
+│   ├── useLogStream.ts    # Streams pod logs into a ring buffer (last 500 lines); supports timestamps, previous, sinceSeconds, tailLines
 │   └── useAlerts.ts       # Derives alerts from critical state transitions
 ├── components/
 │   ├── ResourceTable.tsx  # Scrollable table with search, adaptive columns, spinner, progress bar
@@ -93,11 +132,12 @@ src/
 │   ├── AlertBanner.tsx    # Critical alert banner with queue counter, auto-dismisses after 5s
 │   ├── ConfirmModal.tsx   # Mutation confirmation overlay — never self-triggers
 │   ├── ContextSwitcher.tsx# Kubeconfig context switcher with / search filter
-│   ├── PodDetail.tsx      # Pod detail: container statuses + live logs
-│   ├── SplitLogView.tsx   # Side-by-side log comparison for two pods
-│   └── MultiPodLogView.tsx# Multi-pod log view for 2+ selected pods
+│   ├── PodDetail.tsx      # Pod detail: container statuses + full-featured log view
+│   ├── SplitLogView.tsx   # Side-by-side log comparison for multi-container pods
+│   └── MultiPodLogView.tsx# Multi-pod log view for 2+ selected pods; dynamic height
 └── utils/
     ├── health.ts          # Pure functions: classify resource health
     ├── format.ts          # Pure functions: format age/durations
+    ├── logLevel.ts        # Shared log level types, keywords, color, filter helpers
     └── mutate.ts          # Only file that calls k8s write APIs — always audits
 ```

--- a/src/components/MultiPodLogView.tsx
+++ b/src/components/MultiPodLogView.tsx
@@ -1,19 +1,29 @@
 import React, { useState } from "react";
-import { Box, Text, useInput } from "ink";
+import { Box, Text, useInput, useStdout } from "ink";
 import type { V1Pod, KubeConfig } from "@kubernetes/client-node";
 import { useLogStream } from "../hooks/useLogStream.js";
-import { podHealth } from "../utils/health.js";
-import { HealthStatus } from "../utils/health.js";
+import { podHealth, HealthStatus } from "../utils/health.js";
+import {
+  type LogLevel,
+  filterByLevel,
+  detectLineLevel,
+  levelColor,
+  nextLevel,
+} from "../utils/logLevel.js";
 
-const TAIL_LINES = 25;
+// chrome: view header(1) + view footer(1) + pane border top+bottom(2)
+//       + pane name row(1) + pane ns row(1) + pane separator(1) + pane footer(1) = 8
+const PANE_CHROME = 8;
 
 interface PodPaneProps {
   pod: V1Pod;
   kubeConfig: KubeConfig;
   isFocused: boolean;
+  logLevel: LogLevel;
+  tailLines: number;
 }
 
-function PodPane({ pod, kubeConfig, isFocused }: PodPaneProps) {
+function PodPane({ pod, kubeConfig, isFocused, logLevel, tailLines }: PodPaneProps) {
   const [scrollOffset, setScrollOffset] = useState(0);
 
   const namespace = pod.metadata?.namespace ?? "default";
@@ -29,11 +39,13 @@ function PodPane({ pod, kubeConfig, isFocused }: PodPaneProps) {
     containerName,
   );
 
+  const filtered = filterByLevel(lines, logLevel);
+
   useInput(
     (_input, key) => {
       if (key.upArrow) {
         setScrollOffset((prev) =>
-          Math.min(Math.max(0, lines.length - TAIL_LINES), prev + 3),
+          Math.min(Math.max(0, filtered.length - tailLines), prev + 3),
         );
       }
       if (key.downArrow) {
@@ -44,9 +56,9 @@ function PodPane({ pod, kubeConfig, isFocused }: PodPaneProps) {
   );
 
   const isFollowing = scrollOffset === 0;
-  const endIndex = lines.length - scrollOffset;
-  const startIndex = Math.max(0, endIndex - TAIL_LINES);
-  const visibleLines = lines.slice(startIndex, endIndex);
+  const endIndex = filtered.length - scrollOffset;
+  const startIndex = Math.max(0, endIndex - tailLines);
+  const visibleLines = filtered.slice(startIndex, endIndex);
 
   const health = podHealth(pod);
   const healthColor =
@@ -71,9 +83,16 @@ function PodPane({ pod, kubeConfig, isFocused }: PodPaneProps) {
     >
       {/* Pane header */}
       <Box paddingX={1} justifyContent="space-between">
-        <Text bold color={isFocused ? "cyan" : undefined}>
-          {podName.length > 24 ? podName.slice(0, 23) + "…" : podName}
-        </Text>
+        <Box>
+          <Text bold color={isFocused ? "cyan" : undefined}>
+            {podName.length > 24 ? podName.slice(0, 23) + "…" : podName}
+          </Text>
+          {logLevel !== "ALL" && (
+            <Text color={levelColor(logLevel as Exclude<LogLevel, "ALL">)} bold>
+              {" "}[{logLevel}]
+            </Text>
+          )}
+        </Box>
         <Box>
           <Text color={healthColor}>● {phase}</Text>
           <Text dimColor>
@@ -95,22 +114,27 @@ function PodPane({ pod, kubeConfig, isFocused }: PodPaneProps) {
       </Box>
 
       {/* Log tail */}
-      <Box flexDirection="column" paddingX={1} flexGrow={1} overflow="hidden">
+      <Box flexDirection="column" paddingX={1} height={tailLines} overflow="hidden">
         {error && <Text color="red">{error}</Text>}
-        {lines.length === 0 && !error && (
-          <Text dimColor>Waiting for logs…</Text>
-        )}
-        {visibleLines.map((line, i) => (
-          <Text key={startIndex + i} wrap="truncate">
-            {line}
+        {filtered.length === 0 && !error && (
+          <Text dimColor>
+            {logLevel !== "ALL" ? `No ${logLevel} lines yet…` : "Waiting for logs…"}
           </Text>
-        ))}
+        )}
+        {visibleLines.map((line, i) => {
+          const color = levelColor(detectLineLevel(line));
+          return (
+            <Text key={startIndex + i} color={color} dimColor={!color} wrap="truncate">
+              {line}
+            </Text>
+          );
+        })}
       </Box>
 
       {/* Footer */}
       <Box paddingX={1}>
         <Text dimColor>
-          {isFollowing ? "● follow" : "⏸ paused"} · {lines.length} lines
+          {isFollowing ? "● follow" : "⏸ paused"} · {filtered.length} lines
           {!isFollowing && ` (↑${scrollOffset})`}
         </Text>
       </Box>
@@ -129,7 +153,11 @@ export function MultiPodLogView({
   kubeConfig,
   onClose,
 }: MultiPodLogViewProps) {
+  const { stdout } = useStdout();
   const [focusedIndex, setFocusedIndex] = useState(0);
+  const [logLevel, setLogLevel] = useState<LogLevel>("ALL");
+
+  const tailLines = Math.max(5, (stdout?.rows ?? 24) - PANE_CHROME);
 
   useInput((input, key) => {
     if (key.escape) {
@@ -142,6 +170,10 @@ export function MultiPodLogView({
     if (key.rightArrow || input === "l") {
       setFocusedIndex((i) => Math.min(pods.length - 1, i + 1));
     }
+    // Shift+L cycles log level across all panes
+    if (input === "L") {
+      setLogLevel((cur) => nextLevel(cur));
+    }
   });
 
   return (
@@ -153,8 +185,13 @@ export function MultiPodLogView({
             Multi-pod logs —{" "}
           </Text>
           <Text dimColor>{pods.length} pods</Text>
+          {logLevel !== "ALL" && (
+            <Text color={levelColor(logLevel as Exclude<LogLevel, "ALL">)} bold>
+              {" "}[{logLevel}]
+            </Text>
+          )}
         </Box>
-        <Text dimColor>[←→ / h/l] focus [↑↓] scroll [Esc] back to table</Text>
+        <Text dimColor>[←→/h/l] focus  [↑↓] scroll  [L] level ({logLevel})  [Esc] back</Text>
       </Box>
 
       {/* Panes */}
@@ -165,6 +202,8 @@ export function MultiPodLogView({
             pod={pod}
             kubeConfig={kubeConfig}
             isFocused={i === focusedIndex}
+            logLevel={logLevel}
+            tailLines={tailLines}
           />
         ))}
       </Box>

--- a/src/components/PodDetail.tsx
+++ b/src/components/PodDetail.tsx
@@ -4,6 +4,38 @@ import type { V1Pod, KubeConfig } from "@kubernetes/client-node";
 import { useLogStream } from "../hooks/useLogStream.js";
 import { formatAge } from "../utils/format.js";
 import { SplitLogView } from "./SplitLogView.js";
+import {
+  type LogLevel,
+  LEVEL_KEYWORDS,
+  detectLineLevel,
+  levelColor,
+  nextLevel,
+} from "../utils/logLevel.js";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/** Cycling options for tail size (lines fetched on connect) */
+const TAIL_OPTIONS = [50, 100, 200, 500] as const;
+
+/** Cycling options for since-filter in minutes (undefined = all) */
+const SINCE_OPTIONS = [undefined, 5, 15, 60] as const;
+
+/** Strip RFC3339 timestamp prefix added by the k8s API (timestamps:true) */
+const TS_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z /;
+function stripTs(line: string): string {
+  return line.replace(TS_RE, "");
+}
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface DisplayLine {
+  /** Text shown on screen — includes timestamp when showTimestamps:true */
+  display: string;
+  /** Timestamp-stripped content used for filtering and level detection */
+  content: string;
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
 
 interface PodDetailProps {
   pod: V1Pod;
@@ -14,61 +46,110 @@ interface PodDetailProps {
 export function PodDetail({ pod, kubeConfig, onClose }: PodDetailProps) {
   const { stdout } = useStdout();
   const namespace = pod.metadata?.namespace ?? "default";
-  const podName = pod.metadata?.name ?? "";
+  const podName   = pod.metadata?.name ?? "";
   const containers = pod.spec?.containers ?? [];
+
+  // ── View state ─────────────────────────────────────────────────────────────
   const [activeContainer, setActiveContainer] = useState(0);
-  const [scrollOffset, setScrollOffset] = useState(0);
-  const [follow, setFollow] = useState(true);
-  const [logSearch, setLogSearch] = useState("");
-  const [logSearchMode, setLogSearchMode] = useState(false);
-  const [splitMode, setSplitMode] = useState(false);
+  const [scrollOffset,    setScrollOffset]    = useState(0);
+  const [follow,          setFollow]          = useState(true);
+  const [splitMode,       setSplitMode]       = useState(false);
+
+  // ── Log filter / display state ─────────────────────────────────────────────
+  const [logLevel,       setLogLevel]       = useState<LogLevel>("ALL");
+  const [logSearch,      setLogSearch]      = useState("");
+  const [logSearchMode,  setLogSearchMode]  = useState(false);
+  const [regexMode,      setRegexMode]      = useState(false);
+  const [showTimestamps, setShowTimestamps] = useState(false);
+  const [wrapLines,      setWrapLines]      = useState(false);
+
+  // ── Stream options ─────────────────────────────────────────────────────────
+  const [tailIdx,      setTailIdx]      = useState(1);       // index into TAIL_OPTIONS
+  const [sinceIdx,     setSinceIdx]     = useState(0);       // index into SINCE_OPTIONS
+  const [showPrevious, setShowPrevious] = useState(false);
+
+  const tailLines   = TAIL_OPTIONS[tailIdx];
+  const sinceOption = SINCE_OPTIONS[sinceIdx];
+  const sinceSeconds = sinceOption !== undefined ? sinceOption * 60 : undefined;
 
   const containerName = containers[activeContainer]?.name ?? "";
 
-  // Chrome: title(1) + meta(1) + labels(1) + container rows(capped 4) + log header(1) + log footer(1) + 5 borders
-  const CHROME = 10 + Math.min(containers.length, 4);
+  // Chrome: title(1) + meta(1) + labels(1) + containers(capped 4) + log-header(1)
+  //       + hint-row-1(1) + hint-row-2(1) + round-border(2) + 2 inner borders(2) = 14 + containers
+  const CHROME   = 14 + Math.min(containers.length, 4);
   const logLines = Math.max(5, (stdout?.rows ?? 30) - CHROME);
 
+  // ── Log stream ─────────────────────────────────────────────────────────────
   const { lines, error: logError } = useLogStream(
     kubeConfig,
     namespace,
     podName,
     containerName,
+    { tailLines, timestamps: true, previous: showPrevious, sinceSeconds },
   );
 
-  const displayLines = useMemo(() => {
-    if (!logSearch) return lines;
-    return lines.filter((l) =>
-      l.toLowerCase().includes(logSearch.toLowerCase()),
-    );
-  }, [lines, logSearch]);
+  // ── Derived display lines ──────────────────────────────────────────────────
+  const displayLines = useMemo((): DisplayLine[] => {
+    let items: DisplayLine[] = lines.map((raw) => ({
+      display: showTimestamps ? raw : stripTs(raw),
+      content: stripTs(raw),
+    }));
 
-  const maxOffset = Math.max(0, displayLines.length - logLines);
+    // Level filter
+    if (logLevel !== "ALL") {
+      const kws = LEVEL_KEYWORDS[logLevel];
+      items = items.filter(({ content }) =>
+        kws.some((kw) => content.toLowerCase().includes(kw)),
+      );
+    }
+
+    // Search filter
+    if (logSearch) {
+      if (regexMode) {
+        try {
+          const re = new RegExp(logSearch, "i");
+          items = items.filter(({ content }) => re.test(content));
+        } catch {
+          items = [];
+        }
+      } else {
+        const q = logSearch.toLowerCase();
+        items = items.filter(({ content }) => content.toLowerCase().includes(q));
+      }
+    }
+
+    return items;
+  }, [lines, logLevel, logSearch, regexMode, showTimestamps]);
+
+  const maxOffset      = Math.max(0, displayLines.length - logLines);
   const effectiveOffset = follow
     ? maxOffset
     : Math.min(scrollOffset, maxOffset);
-  const visibleLines = displayLines.slice(
-    effectiveOffset,
-    effectiveOffset + logLines,
-  );
+  const visibleLines   = displayLines.slice(effectiveOffset, effectiveOffset + logLines);
 
+  const scrollPercent =
+    displayLines.length <= logLines
+      ? 100
+      : Math.round((effectiveOffset / maxOffset) * 100);
+
+  // ── Key input ──────────────────────────────────────────────────────────────
   useInput((input, key) => {
+    // Search mode captures all keys
     if (logSearchMode) {
       if (key.escape) {
         setLogSearchMode(false);
         setLogSearch("");
       } else if (key.return) {
         setLogSearchMode(false);
-      } else if (key.backspace || key.delete)
+      } else if (key.backspace || key.delete) {
         setLogSearch((q) => q.slice(0, -1));
-      else if (input && !key.ctrl && !key.meta) setLogSearch((q) => q + input);
+      } else if (input && !key.ctrl && !key.meta) {
+        setLogSearch((q) => q + input);
+      }
       return;
     }
 
-    if (key.escape) {
-      onClose();
-      return;
-    }
+    if (key.escape) { onClose(); return; }
 
     if (input === "m" && containers.length > 1) {
       setSplitMode((v) => !v);
@@ -87,6 +168,7 @@ export function PodDetail({ pod, kubeConfig, onClose }: PodDetailProps) {
     }
 
     if (!splitMode) {
+      // Scroll
       if (key.upArrow) {
         setFollow(false);
         setScrollOffset((o) => Math.max(0, o - 1));
@@ -96,50 +178,135 @@ export function PodDetail({ pod, kubeConfig, onClose }: PodDetailProps) {
         setScrollOffset(next);
         if (next >= maxOffset) setFollow(true);
       }
-      if (input === "g") {
+      if (input === "g") { setScrollOffset(0);        setFollow(false); }
+      if (input === "G") { setScrollOffset(maxOffset); setFollow(true);  }
+      if (input === "f") setFollow((v) => !v);
+
+      // Search
+      if (input === "/") { setLogSearchMode(true); setLogSearch(""); }
+      if (input === "r") setRegexMode((v) => !v);
+
+      // Display toggles
+      if (input === "l") {
+        setLogLevel((cur) => nextLevel(cur));
         setScrollOffset(0);
-        setFollow(false);
-      }
-      if (input === "G") {
-        setScrollOffset(maxOffset);
         setFollow(true);
       }
-      if (input === "f") setFollow((v) => !v);
-      if (input === "/") {
-        setLogSearchMode(true);
-        setLogSearch("");
+      if (input === "t") setShowTimestamps((v) => !v);
+      if (input === "w") setWrapLines((v) => !v);
+
+      // Stream options (restart stream)
+      if (input === "+" || input === "=") {
+        setTailIdx((i) => Math.min(TAIL_OPTIONS.length - 1, i + 1));
+        setScrollOffset(0);
+        setFollow(true);
+      }
+      if (input === "-") {
+        setTailIdx((i) => Math.max(0, i - 1));
+        setScrollOffset(0);
+        setFollow(true);
+      }
+      if (input === "s") {
+        setSinceIdx((i) => (i + 1) % SINCE_OPTIONS.length);
+        setScrollOffset(0);
+        setFollow(true);
+      }
+      if (input === "p") {
+        setShowPrevious((v) => {
+          // Switching to previous: force follow off (prev logs are finite)
+          if (!v) setFollow(false);
+          else    setFollow(true);
+          return !v;
+        });
+        setScrollOffset(0);
       }
     }
   });
 
-  // Derived pod info
-  const phase = pod.status?.phase ?? "Unknown";
-  const phaseColor =
-    phase === "Running" ? "green" : phase === "Pending" ? "yellow" : "red";
-  const podIP = pod.status?.podIP ?? "-";
-  const nodeName = pod.spec?.nodeName ?? "-";
-  const labels = pod.metadata?.labels ?? {};
-  const labelStr = Object.entries(labels)
-    .map(([k, v]) => `${k}=${v}`)
-    .join("  ");
-  const scrollPercent =
-    displayLines.length <= logLines
-      ? 100
-      : Math.round((effectiveOffset / maxOffset) * 100);
+  // ── Derived pod metadata ───────────────────────────────────────────────────
+  const phase      = pod.status?.phase ?? "Unknown";
+  const phaseColor = phase === "Running" ? "green" : phase === "Pending" ? "yellow" : "red";
+  const podIP      = pod.status?.podIP   ?? "-";
+  const nodeName   = pod.spec?.nodeName  ?? "-";
+  const labels     = pod.metadata?.labels ?? {};
+  const labelStr   = Object.entries(labels).map(([k, v]) => `${k}=${v}`).join("  ");
 
+  // ── Render helpers ─────────────────────────────────────────────────────────
+
+  /** Highlight a single display line for search matches */
+  function renderLine(dl: DisplayLine, idx: number) {
+    const { display, content } = dl;
+    const color    = levelColor(detectLineLevel(content));
+    const wrapProp = wrapLines ? "wrap" : "truncate";
+
+    if (!logSearch) {
+      return (
+        <Text key={idx} color={color} dimColor={!color} wrap={wrapProp}>
+          {display}
+        </Text>
+      );
+    }
+
+    // Regex highlight
+    if (regexMode) {
+      try {
+        const re  = new RegExp(`(${logSearch})`, "gi");
+        const parts = display.split(re);
+        return (
+          <Text key={idx} color={color} dimColor={!color} wrap={wrapProp}>
+            {parts.map((part, pi) =>
+              re.test(part) ? (
+                <Text key={pi} backgroundColor="yellow" color="black">{part}</Text>
+              ) : (
+                part
+              ),
+            )}
+          </Text>
+        );
+      } catch {
+        return <Text key={idx} color={color} dimColor={!color} wrap={wrapProp}>{display}</Text>;
+      }
+    }
+
+    // Plain-string highlight
+    const q   = logSearch.toLowerCase();
+    const pos = display.toLowerCase().indexOf(q);
+    if (pos === -1) {
+      return <Text key={idx} color={color} dimColor={!color} wrap={wrapProp}>{display}</Text>;
+    }
+    return (
+      <Text key={idx} color={color} dimColor={!color} wrap={wrapProp}>
+        {display.slice(0, pos)}
+        <Text backgroundColor="yellow" color="black">
+          {display.slice(pos, pos + logSearch.length)}
+        </Text>
+        {display.slice(pos + logSearch.length)}
+      </Text>
+    );
+  }
+
+  // ── Status badges shown in log header ──────────────────────────────────────
+  const badges: React.ReactNode[] = [];
+  if (logLevel !== "ALL")
+    badges.push(<Text key="lvl" color={levelColor(logLevel as Exclude<LogLevel,"ALL">)} bold> [{logLevel}]</Text>);
+  if (showPrevious)
+    badges.push(<Text key="prev" color="magenta" bold> [PREV]</Text>);
+  if (sinceOption !== undefined)
+    badges.push(<Text key="since" color="cyan" dimColor> [{sinceOption}m]</Text>);
+  if (showTimestamps)
+    badges.push(<Text key="ts" color="cyan" dimColor> [TS]</Text>);
+  if (wrapLines)
+    badges.push(<Text key="wrap" color="cyan" dimColor> [WRAP]</Text>);
+  if (regexMode)
+    badges.push(<Text key="re" color="yellow" dimColor> [RE]</Text>);
+
+  // ── JSX ───────────────────────────────────────────────────────────────────
   return (
-    <Box
-      flexDirection="column"
-      borderStyle="round"
-      borderColor="cyan"
-      flexGrow={1}
-    >
+    <Box flexDirection="column" borderStyle="round" borderColor="cyan" flexGrow={1}>
       {/* Title bar */}
       <Box justifyContent="space-between" paddingX={1}>
         <Box>
-          <Text bold color="cyan">
-            Pod:{" "}
-          </Text>
+          <Text bold color="cyan">Pod: </Text>
           <Text bold>{podName}</Text>
           <Text dimColor> ns: {namespace}</Text>
         </Box>
@@ -152,22 +319,11 @@ export function PodDetail({ pod, kubeConfig, onClose }: PodDetailProps) {
       </Box>
 
       {/* Metadata row */}
-      <Box
-        paddingX={1}
-        borderStyle="single"
-        borderTop={false}
-        borderLeft={false}
-        borderRight={false}
-        borderBottom={true}
-      >
+      <Box paddingX={1} borderStyle="single" borderTop={false} borderLeft={false} borderRight={false} borderBottom={true}>
         <Text color={phaseColor}>● {phase} </Text>
-        <Text dimColor>IP: </Text>
-        <Text>{podIP} </Text>
+        <Text dimColor>IP: </Text><Text>{podIP} </Text>
         <Text dimColor>Node: </Text>
-        <Text>
-          {nodeName.length > 24 ? nodeName.slice(0, 23) + "…" : nodeName}
-          {"  "}
-        </Text>
+        <Text>{nodeName.length > 24 ? nodeName.slice(0, 23) + "…" : nodeName}{"  "}</Text>
         <Text dimColor>Age: {formatAge(pod.metadata?.creationTimestamp)}</Text>
       </Box>
 
@@ -175,53 +331,29 @@ export function PodDetail({ pod, kubeConfig, onClose }: PodDetailProps) {
       {labelStr ? (
         <Box paddingX={1}>
           <Text dimColor>Labels: </Text>
-          <Text>
-            {labelStr.length > 100 ? labelStr.slice(0, 99) + "…" : labelStr}
-          </Text>
+          <Text>{labelStr.length > 100 ? labelStr.slice(0, 99) + "…" : labelStr}</Text>
         </Box>
       ) : null}
 
       {/* Containers summary */}
-      <Box
-        flexDirection="column"
-        paddingX={1}
-        borderStyle="single"
-        borderTop={false}
-        borderLeft={false}
-        borderRight={false}
-        borderBottom={true}
-      >
+      <Box flexDirection="column" paddingX={1} borderStyle="single" borderTop={false} borderLeft={false} borderRight={false} borderBottom={true}>
         {containers.slice(0, 4).map((c, i) => {
-          const cs = pod.status?.containerStatuses?.find(
-            (s) => s.name === c.name,
-          );
+          const cs       = pod.status?.containerStatuses?.find((s) => s.name === c.name);
           const isActive = i === activeContainer && !splitMode;
-          const image = c.image ?? "";
-          const shortImage = (image.split("/").pop() ?? image).slice(0, 26);
-          const cpuR = c.resources?.requests?.["cpu"] ?? "-";
-          const memR = c.resources?.requests?.["memory"] ?? "-";
-          const cpuL = c.resources?.limits?.["cpu"] ?? "-";
-          const memL = c.resources?.limits?.["memory"] ?? "-";
+          const image    = c.image ?? "";
+          const shortImg = (image.split("/").pop() ?? image).slice(0, 26);
+          const cpuR     = c.resources?.requests?.["cpu"]    ?? "-";
+          const memR     = c.resources?.requests?.["memory"] ?? "-";
+          const cpuL     = c.resources?.limits?.["cpu"]      ?? "-";
+          const memL     = c.resources?.limits?.["memory"]   ?? "-";
           const restarts = cs?.restartCount ?? 0;
-
           return (
             <Box key={c.name}>
-              <Text color={isActive ? "cyan" : "gray"}>
-                {isActive ? "▶ " : "  "}
-              </Text>
-              <Text bold={isActive} color={isActive ? "cyan" : undefined}>
-                {c.name}
-              </Text>
-              <Text dimColor> {shortImage}</Text>
-              <Text color={cs?.ready ? "green" : "red"}>
-                {cs?.ready ? "  ● Ready" : "  ● NotReady"}
-              </Text>
-              <Text dimColor>
-                {"  cpu "}
-                {cpuR}/{cpuL}
-                {"  mem "}
-                {memR}/{memL}
-              </Text>
+              <Text color={isActive ? "cyan" : "gray"}>{isActive ? "▶ " : "  "}</Text>
+              <Text bold={isActive} color={isActive ? "cyan" : undefined}>{c.name}</Text>
+              <Text dimColor> {shortImg}</Text>
+              <Text color={cs?.ready ? "green" : "red"}>{cs?.ready ? "  ● Ready" : "  ● NotReady"}</Text>
+              <Text dimColor>{"  cpu "}{cpuR}/{cpuL}{"  mem "}{memR}/{memL}</Text>
               {restarts > 0 && <Text color="yellow"> ↺{restarts}</Text>}
             </Box>
           );
@@ -231,14 +363,12 @@ export function PodDetail({ pod, kubeConfig, onClose }: PodDetailProps) {
         )}
       </Box>
 
-      {/* Log area — split or single */}
+      {/* Log area */}
       {splitMode ? (
         <>
-          <SplitLogView pod={pod} kubeConfig={kubeConfig} />
+          <SplitLogView pod={pod} kubeConfig={kubeConfig} logLevel={logLevel} />
           <Box paddingX={1}>
-            <Text dimColor>
-              [m] single mode [Esc] close — all containers auto-follow
-            </Text>
+            <Text dimColor>[m] single mode  [Esc] close — all containers auto-follow</Text>
           </Box>
         </>
       ) : (
@@ -247,35 +377,36 @@ export function PodDetail({ pod, kubeConfig, onClose }: PodDetailProps) {
           <Box paddingX={1} justifyContent="space-between">
             {logSearchMode ? (
               <Box>
-                <Text color="cyan" bold>
-                  /{" "}
-                </Text>
+                {regexMode && <Text color="yellow" bold>re</Text>}
+                <Text color="cyan" bold>/ </Text>
                 <Text>{logSearch}</Text>
                 <Text color="cyan">█</Text>
               </Box>
             ) : logSearch ? (
               <Box>
-                <Text color="yellow">/ {logSearch}</Text>
-                <Text dimColor> {displayLines.length} match esc clear</Text>
+                <Text color="yellow">{regexMode ? "re/" : "/"}{logSearch}</Text>
+                <Text dimColor> {displayLines.length} match  esc clear</Text>
               </Box>
             ) : (
-              <Text dimColor bold>
-                Logs ({containerName})
-              </Text>
+              <Box>
+                <Text dimColor bold>Logs ({containerName})</Text>
+                {badges}
+              </Box>
             )}
             <Box>
-              {follow ? (
+              {showPrevious ? (
+                <Text color="magenta">◀ previous</Text>
+              ) : follow ? (
                 <Text color="green">● follow</Text>
               ) : (
                 <Text color="yellow">⏸ paused</Text>
               )}
               <Text dimColor>
-                {"  "}
-                {effectiveOffset + 1}-
+                {"  "}{effectiveOffset + 1}-
                 {Math.min(effectiveOffset + logLines, displayLines.length)}/
                 {displayLines.length}
-                {"  "}
-                {scrollPercent}%
+                {"  "}{scrollPercent}%
+                {"  tail:"}{tailLines}
               </Text>
             </Box>
           </Box>
@@ -296,34 +427,22 @@ export function PodDetail({ pod, kubeConfig, onClose }: PodDetailProps) {
               <Text dimColor>
                 {logSearch
                   ? `No matches for "${logSearch}"`
+                  : showPrevious
+                  ? "No previous logs found"
                   : "Waiting for logs..."}
               </Text>
             )}
-            {visibleLines.map((line, i) => {
-              if (logSearch) {
-                const idx = line.toLowerCase().indexOf(logSearch.toLowerCase());
-                if (idx !== -1) {
-                  return (
-                    <Text key={effectiveOffset + i}>
-                      {line.slice(0, idx)}
-                      <Text backgroundColor="yellow" color="black">
-                        {line.slice(idx, idx + logSearch.length)}
-                      </Text>
-                      {line.slice(idx + logSearch.length)}
-                    </Text>
-                  );
-                }
-              }
-              return <Text key={effectiveOffset + i}>{line}</Text>;
-            })}
+            {visibleLines.map((dl, i) => renderLine(dl, effectiveOffset + i))}
           </Box>
 
-          {/* Log footer */}
-          <Box paddingX={1}>
+          {/* Hint footer — two compact rows */}
+          <Box flexDirection="column" paddingX={1}>
             <Text dimColor>
-              [↑↓] Scroll [g] Top [G] Bottom [f] Follow [/] Search
-              {containers.length > 1 ? "  [[] []] Container" : ""}
-              {"  [Esc] Close"}
+              [↑↓][g/G] Scroll  [f] Follow  [/] Search  [r] Regex({regexMode ? "ON" : "off"})  [l] Level({logLevel})  [Esc] Close
+            </Text>
+            <Text dimColor>
+              [t] Timestamps({showTimestamps ? "ON" : "off"})  [w] Wrap({wrapLines ? "ON" : "off"})  [s] Since({sinceOption !== undefined ? `${sinceOption}m` : "all"})  [p] Prev({showPrevious ? "ON" : "off"})  [+/-] Tail({tailLines})
+              {containers.length > 1 ? "  [[] []] Ctr" : ""}
             </Text>
           </Box>
         </Box>

--- a/src/components/SplitLogView.tsx
+++ b/src/components/SplitLogView.tsx
@@ -2,6 +2,12 @@ import React from "react";
 import { Box, Text } from "ink";
 import type { V1Pod, KubeConfig } from "@kubernetes/client-node";
 import { useLogStream } from "../hooks/useLogStream.js";
+import {
+  type LogLevel,
+  filterByLevel,
+  detectLineLevel,
+  levelColor,
+} from "../utils/logLevel.js";
 
 const TAIL_LINES = 20;
 
@@ -12,6 +18,7 @@ interface ContainerTailPaneProps {
   containerName: string;
   isReady: boolean;
   restarts: number;
+  logLevel: LogLevel;
 }
 
 function ContainerTailPane({
@@ -21,6 +28,7 @@ function ContainerTailPane({
   containerName,
   isReady,
   restarts,
+  logLevel,
 }: ContainerTailPaneProps) {
   const { lines, error } = useLogStream(
     kubeConfig,
@@ -28,7 +36,8 @@ function ContainerTailPane({
     podName,
     containerName,
   );
-  const tail = lines.slice(-TAIL_LINES);
+  const filtered = filterByLevel(lines, logLevel);
+  const tail = filtered.slice(-TAIL_LINES);
 
   return (
     <Box
@@ -40,7 +49,14 @@ function ContainerTailPane({
     >
       {/* Pane header */}
       <Box paddingX={1} justifyContent="space-between">
-        <Text bold>{containerName}</Text>
+        <Box>
+          <Text bold>{containerName}</Text>
+          {logLevel !== "ALL" && (
+            <Text color={levelColor(logLevel as Exclude<LogLevel, "ALL">)} bold>
+              {" "}[{logLevel}]
+            </Text>
+          )}
+        </Box>
         <Box>
           <Text color={isReady ? "green" : "red"}>
             {isReady ? "● Ready" : "● NotReady"}
@@ -52,17 +68,26 @@ function ContainerTailPane({
       {/* Log tail */}
       <Box flexDirection="column" paddingX={1} flexGrow={1}>
         {error && <Text color="red">{error}</Text>}
-        {lines.length === 0 && !error && (
-          <Text dimColor>Waiting for logs...</Text>
+        {filtered.length === 0 && !error && (
+          <Text dimColor>
+            {logLevel !== "ALL"
+              ? `No ${logLevel} lines yet…`
+              : "Waiting for logs..."}
+          </Text>
         )}
-        {tail.map((line, i) => (
-          <Text key={lines.length - tail.length + i}>{line}</Text>
-        ))}
+        {tail.map((line, i) => {
+          const color = levelColor(detectLineLevel(line));
+          return (
+            <Text key={filtered.length - tail.length + i} color={color} dimColor={!color} wrap="truncate">
+              {line}
+            </Text>
+          );
+        })}
       </Box>
 
       {/* Footer */}
       <Box paddingX={1}>
-        <Text dimColor>● auto-follow {lines.length} lines</Text>
+        <Text dimColor>● auto-follow {filtered.length} lines</Text>
       </Box>
     </Box>
   );
@@ -71,9 +96,10 @@ function ContainerTailPane({
 export interface SplitLogViewProps {
   pod: V1Pod;
   kubeConfig: KubeConfig;
+  logLevel: LogLevel;
 }
 
-export function SplitLogView({ pod, kubeConfig }: SplitLogViewProps) {
+export function SplitLogView({ pod, kubeConfig, logLevel }: SplitLogViewProps) {
   const namespace = pod.metadata?.namespace ?? "default";
   const podName = pod.metadata?.name ?? "";
   const containers = pod.spec?.containers ?? [];
@@ -93,6 +119,7 @@ export function SplitLogView({ pod, kubeConfig }: SplitLogViewProps) {
             containerName={c.name}
             isReady={cs?.ready ?? false}
             restarts={cs?.restartCount ?? 0}
+            logLevel={logLevel}
           />
         );
       })}

--- a/src/hooks/useLogStream.ts
+++ b/src/hooks/useLogStream.ts
@@ -6,6 +6,17 @@ import { stripVTControlCharacters } from "node:util";
 const RING_BUFFER_SIZE = 500;
 const RECONNECT_DELAY_MS = 2000;
 
+export interface UseLogStreamOptions {
+  /** How many historical lines to fetch on connect (default: 100) */
+  tailLines?: number;
+  /** Request RFC3339 timestamp prefix on every line (default: true) */
+  timestamps?: boolean;
+  /** Stream the previously-terminated container instance (default: false) */
+  previous?: boolean;
+  /** Only return logs newer than this many seconds ago (default: undefined = all) */
+  sinceSeconds?: number;
+}
+
 export interface UseLogStreamResult {
   lines: string[];
   error: string | null;
@@ -16,18 +27,24 @@ export function useLogStream(
   namespace: string,
   podName: string,
   containerName: string,
+  options: UseLogStreamOptions = {},
 ): UseLogStreamResult {
   const [lines, setLines] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
 
+  // Destructure so primitives go into the dep array (avoids object-identity issues)
+  const {
+    tailLines = 100,
+    timestamps = true,
+    previous = false,
+    sinceSeconds,
+  } = options;
+
   useEffect(() => {
-    // Local closure flag — each effect run owns its own `active` variable,
-    // so stale async callbacks from a previous run can never write to state.
     let active = true;
     let abortRequest: (() => void) | null = null;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
 
-    // Reset lines when the target (pod/container) changes
     setLines([]);
     setError(null);
 
@@ -54,10 +71,13 @@ export function useLogStream(
         }
       });
 
-      // Stream ended naturally (server closed the follow connection) — reconnect
       logStream.on("end", () => {
         if (!active) return;
-        retryTimer = setTimeout(startStream, RECONNECT_DELAY_MS);
+        // Previous-container logs are finite — don't reconnect, we have all of them.
+        // Live logs: reconnect when the server closes the follow connection.
+        if (!previous) {
+          retryTimer = setTimeout(startStream, RECONNECT_DELAY_MS);
+        }
       });
 
       logStream.on("error", (err) => {
@@ -73,12 +93,14 @@ export function useLogStream(
           containerName,
           logStream,
           {
-            follow: true,
-            tailLines: 100,
+            follow: !previous, // can't follow previous-container logs
+            tailLines,
+            timestamps,
+            previous,
+            ...(sinceSeconds !== undefined ? { sinceSeconds } : {}),
           },
         );
         if (!active) {
-          // Effect was cleaned up while we awaited — abort immediately
           (req as any).destroy?.();
           return;
         }
@@ -98,7 +120,7 @@ export function useLogStream(
       if (retryTimer !== null) clearTimeout(retryTimer);
       abortRequest?.();
     };
-  }, [kubeConfig, namespace, podName, containerName]);
+  }, [kubeConfig, namespace, podName, containerName, tailLines, timestamps, previous, sinceSeconds]);
 
   return { lines, error };
 }

--- a/src/utils/logLevel.ts
+++ b/src/utils/logLevel.ts
@@ -1,0 +1,34 @@
+export type LogLevel = "ALL" | "ERROR" | "WARN" | "INFO";
+export const LOG_LEVELS: LogLevel[] = ["ALL", "ERROR", "WARN", "INFO"];
+
+export const LEVEL_KEYWORDS: Record<Exclude<LogLevel, "ALL">, string[]> = {
+  ERROR: ["error", "fatal", "exception", "critical"],
+  WARN:  ["warn", "warning"],
+  INFO:  ["info"],
+};
+
+export function detectLineLevel(line: string): Exclude<LogLevel, "ALL"> | null {
+  const l = line.toLowerCase();
+  if (LEVEL_KEYWORDS.ERROR.some((kw) => l.includes(kw))) return "ERROR";
+  if (LEVEL_KEYWORDS.WARN.some((kw) => l.includes(kw)))  return "WARN";
+  if (LEVEL_KEYWORDS.INFO.some((kw) => l.includes(kw)))  return "INFO";
+  return null;
+}
+
+export function levelColor(level: Exclude<LogLevel, "ALL"> | null): string | undefined {
+  if (level === "ERROR") return "red";
+  if (level === "WARN")  return "yellow";
+  if (level === "INFO")  return "cyan";
+  return undefined;
+}
+
+export function filterByLevel(lines: string[], level: LogLevel): string[] {
+  if (level === "ALL") return lines;
+  const keywords = LEVEL_KEYWORDS[level];
+  return lines.filter((l) => keywords.some((kw) => l.toLowerCase().includes(kw)));
+}
+
+export function nextLevel(current: LogLevel): LogLevel {
+  const idx = LOG_LEVELS.indexOf(current);
+  return LOG_LEVELS[(idx + 1) % LOG_LEVELS.length];
+}


### PR DESCRIPTION
- Add log level filter (ALL/ERROR/WARN/INFO) with color-coded lines across PodDetail, SplitLogView, and MultiPodLogView (Shift+L in multi-pod view)
- Add regex search mode toggle (r) with match highlighting
- Add timestamp toggle (t) — always streamed, shown/hidden without restart
- Add line wrap toggle (w) — truncate vs full-wrap per line
- Add tail size control (+/-) cycling 50/100/200/500 lines
- Add since filter (s) cycling all/5m/15m/1h
- Add previous container log mode (p) for crash-loop debugging
- Fix MultiPodLogView log panes to fill terminal height dynamically
- Extract shared logLevel helpers to src/utils/logLevel.ts
- Extend useLogStream with timestamps, previous, sinceSeconds, tailLines options
- Update README with full pod log keyboard reference