### PR TITLE
feat: favourites, restart graph, crash drill-down, log export, deploy…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,9 +17,12 @@ import { ContextSwitcher } from "./components/ContextSwitcher.js";
 import { NamespacePicker } from "./components/NamespacePicker.js";
 import { PodDetail } from "./components/PodDetail.js";
 import { MultiPodLogView } from "./components/MultiPodLogView.js";
+import { DeploymentDetail } from "./components/DeploymentDetail.js";
 import { useKubeClient } from "./hooks/useKubeClient.js";
 import { useResources } from "./hooks/useResources.js";
 import { useAlerts } from "./hooks/useAlerts.js";
+import { useFavourites } from "./hooks/useFavourites.js";
+import { useRestartHistory } from "./hooks/useRestartHistory.js";
 import {
   podHealth,
   deploymentHealth,
@@ -50,6 +53,7 @@ export function App({ mutationsEnabled, maxReplicas }: AppProps) {
     new Set(),
   );
   const [multiPodView, setMultiPodView] = useState(false);
+  const [detailDeployment, setDetailDeployment] = useState<V1Deployment | null>(null);
   const [pendingMutation, setPendingMutation] = useState<null | {
     title: string;
     description: string;
@@ -58,6 +62,7 @@ export function App({ mutationsEnabled, maxReplicas }: AppProps) {
   }>(null);
 
   const kubeClient = useKubeClient();
+  const { favourites, toggle: toggleFavourite } = useFavourites();
 
   const pods = useResources<V1Pod>(kubeClient.kubeConfig, "/api/v1/pods", {
     namespaced: true,
@@ -93,10 +98,12 @@ export function App({ mutationsEnabled, maxReplicas }: AppProps) {
 
   const getPodHealth = useCallback((pod: V1Pod) => podHealth(pod), []);
   const { alerts, dismiss } = useAlerts(pods.resources, getPodHealth);
+  const restartHistory = useRestartHistory(pods.resources);
 
   // Dynamic chrome: accounts for whether summary bar and alert banner are currently rendered
   const isOverlay =
     !!detailPod ||
+    !!detailDeployment ||
     multiPodView ||
     showContextSwitcher ||
     showNamespacePicker ||
@@ -117,6 +124,7 @@ export function App({ mutationsEnabled, maxReplicas }: AppProps) {
       showContextSwitcher ||
       showNamespacePicker ||
       detailPod ||
+      detailDeployment ||
       multiPodView
     )
       return;
@@ -165,14 +173,14 @@ export function App({ mutationsEnabled, maxReplicas }: AppProps) {
         }
       }
 
-      if (mutationsEnabled && activeTab === parseInt("1", 10)) {
+      if (activeTab === 1) {
         const deployArr = Array.from(deployments.resources.values());
         const deploy = deployArr[selectedIndex];
         if (!deploy) return;
         const name = deploy.metadata?.name ?? "";
         const ns = deploy.metadata?.namespace ?? "";
 
-        if (input === "R") {
+        if (mutationsEnabled && input === "R") {
           setPendingMutation({
             title: "Confirm Restart",
             description: `Rollout restart deployment "${name}" in namespace "${ns}"?`,
@@ -353,14 +361,21 @@ export function App({ mutationsEnabled, maxReplicas }: AppProps) {
       }));
   }
 
+  function pinFavourites(rows: ResourceRow[]): ResourceRow[] {
+    if (favourites.size === 0) return rows;
+    const pinned = rows.filter((r) => favourites.has(r.uid));
+    const rest = rows.filter((r) => !favourites.has(r.uid));
+    return [...pinned, ...rest];
+  }
+
   const tabRows: ResourceRow[][] = [
-    buildPodRows(),
-    buildDeploymentRows(),
-    buildServiceRows(),
+    pinFavourites(buildPodRows()),
+    pinFavourites(buildDeploymentRows()),
+    pinFavourites(buildServiceRows()),
     buildNamespaceRows(),
     buildNodeRows(),
     buildEventRows(),
-    buildPVCRows(),
+    pinFavourites(buildPVCRows()),
   ];
 
   const tabSummaries = tabRows.map((rows) => ({
@@ -402,7 +417,10 @@ export function App({ mutationsEnabled, maxReplicas }: AppProps) {
       return "[↑↓] Navigate  [Enter] Select  [Esc] Cancel";
     }
     if (detailPod) {
-      return "[↑↓] Scroll  [[] []] Container  [f] Follow  [/] Search  [Esc] Close";
+      return "[↑↓] Scroll  [[] []] Container  [f] Follow  [/] Search  [h] Restarts  [e] Export  [Esc] Close";
+    }
+    if (detailDeployment) {
+      return "[↑↓] Nav  [r/Enter] Rollback  [Esc] Close";
     }
     if (multiPodView) {
       return "[↑↓] Scroll  [Esc] Close";
@@ -523,6 +541,35 @@ export function App({ mutationsEnabled, maxReplicas }: AppProps) {
             pod={detailPod}
             kubeConfig={kubeClient.kubeConfig}
             onClose={() => setDetailPod(null)}
+            restartHistory={restartHistory}
+          />
+        ) : detailDeployment ? (
+          <DeploymentDetail
+            deployment={detailDeployment}
+            kubeConfig={kubeClient.kubeConfig}
+            onClose={() => setDetailDeployment(null)}
+            onRollback={(deploy, revision) => {
+              const rs = Array.from(deployments.resources.values()).find(
+                (d) => d.metadata?.uid === deploy.metadata?.uid,
+              );
+              if (!rs) return;
+              const name = deploy.metadata?.name ?? "";
+              const ns = deploy.metadata?.namespace ?? "";
+              setPendingMutation({
+                title: "Confirm Rollback",
+                description: `Roll back "${name}" to revision #${revision}?`,
+                namespace: ns,
+                action: () =>
+                  mutate(kubeClient.appsV1 as any, {
+                    action: MutationAction.RollbackDeployment,
+                    name,
+                    namespace: ns,
+                    templateSpec: deploy.spec?.template?.spec as Record<string, unknown>,
+                    revision,
+                  }),
+              });
+              setDetailDeployment(null);
+            }}
           />
         ) : showContextSwitcher ? (
           <ContextSwitcher
@@ -567,7 +614,6 @@ export function App({ mutationsEnabled, maxReplicas }: AppProps) {
               if (activeTab === 0) {
                 // If 2+ pods are checked, open multi-pod view
                 if (selectedPodUids.size >= 2) {
-                  // Also make sure the activated row is included
                   setSelectedPodUids((prev) => new Set([...prev, row.uid]));
                   setMultiPodView(true);
                   return;
@@ -577,7 +623,15 @@ export function App({ mutationsEnabled, maxReplicas }: AppProps) {
                 );
                 if (pod) setDetailPod(pod);
               }
+              if (activeTab === 1) {
+                const deploy = Array.from(deployments.resources.values()).find(
+                  (d) => d.metadata?.uid === row.uid,
+                );
+                if (deploy) setDetailDeployment(deploy);
+              }
             }}
+            favouriteUids={favourites}
+            onToggleFavourite={(row) => toggleFavourite(row.uid)}
             selectedUids={activeTab === 0 ? selectedPodUids : undefined}
             onToggleSelect={
               activeTab === 0

--- a/src/components/DeploymentDetail.tsx
+++ b/src/components/DeploymentDetail.tsx
@@ -1,0 +1,229 @@
+import React, { useState, useEffect } from "react";
+import { Box, Text, useInput } from "ink";
+import type { V1Deployment, V1ReplicaSet, KubeConfig } from "@kubernetes/client-node";
+import { AppsV1Api } from "@kubernetes/client-node";
+import { formatAge } from "../utils/format.js";
+
+interface Revision {
+  revision: number;
+  rs: V1ReplicaSet;
+  image: string;
+  replicas: number;
+  createdAt?: Date | string;
+}
+
+interface DeploymentDetailProps {
+  deployment: V1Deployment;
+  kubeConfig: KubeConfig;
+  onClose: () => void;
+  onRollback?: (deployment: V1Deployment, revision: number) => void;
+}
+
+export function DeploymentDetail({
+  deployment,
+  kubeConfig,
+  onClose,
+  onRollback,
+}: DeploymentDetailProps) {
+  const [revisions, setRevisions] = useState<Revision[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [cursor, setCursor] = useState(0);
+  const [confirmRollback, setConfirmRollback] = useState<Revision | null>(null);
+
+  const name = deployment.metadata?.name ?? "";
+  const namespace = deployment.metadata?.namespace ?? "default";
+  const currentRevision = Number(
+    deployment.metadata?.annotations?.["deployment.kubernetes.io/revision"] ?? "0",
+  );
+
+  useEffect(() => {
+    async function fetchReplicaSets() {
+      try {
+        const appsV1 = kubeConfig.makeApiClient(AppsV1Api);
+        const selector = deployment.spec?.selector?.matchLabels ?? {};
+        const labelSelector = Object.entries(selector)
+          .map(([k, v]) => `${k}=${v}`)
+          .join(",");
+
+        const res = await appsV1.listNamespacedReplicaSet(
+          namespace,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          labelSelector,
+        );
+
+        const rsList = (res.body?.items ?? []) as V1ReplicaSet[];
+        const parsed: Revision[] = rsList
+          .map((rs) => {
+            const rev = Number(
+              rs.metadata?.annotations?.["deployment.kubernetes.io/revision"] ?? "0",
+            );
+            const image =
+              rs.spec?.template?.spec?.containers?.[0]?.image ?? "(unknown)";
+            return {
+              revision: rev,
+              rs,
+              image,
+              replicas: rs.spec?.replicas ?? 0,
+              createdAt: rs.metadata?.creationTimestamp,
+            };
+          })
+          .filter((r) => r.revision > 0)
+          .sort((a, b) => b.revision - a.revision);
+
+        setRevisions(parsed);
+        setLoading(false);
+      } catch (err) {
+        setError(String(err));
+        setLoading(false);
+      }
+    }
+    fetchReplicaSets();
+  }, []);
+
+  useInput((input, key) => {
+    if (confirmRollback) {
+      if (input === "y" || key.return) {
+        onRollback?.(deployment, confirmRollback.revision);
+        setConfirmRollback(null);
+        onClose();
+      }
+      if (input === "n" || key.escape) setConfirmRollback(null);
+      return;
+    }
+    if (key.escape) { onClose(); return; }
+    if (key.upArrow) setCursor((i) => Math.max(0, i - 1));
+    if (key.downArrow) setCursor((i) => Math.min(revisions.length - 1, i + 1));
+    if ((input === "r" || key.return) && revisions[cursor]) {
+      const rev = revisions[cursor];
+      if (rev.revision !== currentRevision) setConfirmRollback(rev);
+    }
+  });
+
+  if (confirmRollback) {
+    return (
+      <Box
+        flexDirection="column"
+        borderStyle="round"
+        borderColor="yellow"
+        padding={1}
+      >
+        <Text bold color="yellow">
+          Confirm Rollback
+        </Text>
+        <Text>
+          Roll back <Text bold>{name}</Text> to revision{" "}
+          <Text bold color="cyan">
+            #{confirmRollback.revision}
+          </Text>
+          ?
+        </Text>
+        <Text dimColor>Image: {confirmRollback.image}</Text>
+        <Box marginTop={1}>
+          <Text color="green">[y/Enter] Confirm </Text>
+          <Text color="red">[n/Esc] Cancel</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="cyan"
+      padding={1}
+    >
+      {/* Header */}
+      <Box justifyContent="space-between">
+        <Box>
+          <Text bold color="cyan">
+            Rollout History —{" "}
+          </Text>
+          <Text bold>{name}</Text>
+          <Text dimColor> ns: {namespace}</Text>
+        </Box>
+        <Text dimColor>[↑↓] Nav  [r/Enter] Rollback  [Esc] Close</Text>
+      </Box>
+
+      {/* Current state */}
+      <Box marginTop={1}>
+        <Text dimColor>
+          Current revision:{" "}
+          <Text color="green" bold>
+            #{currentRevision}
+          </Text>
+          {"  "}Ready:{" "}
+          {deployment.status?.readyReplicas ?? 0}/
+          {deployment.status?.replicas ?? 0}
+        </Text>
+      </Box>
+
+      {/* Column header */}
+      <Box
+        marginTop={1}
+        borderStyle="single"
+        borderTop={false}
+        borderLeft={false}
+        borderRight={false}
+        borderBottom={true}
+      >
+        <Text bold color="cyan">
+          {"  REV  IMAGE                                    REPLICAS  AGE     "}
+        </Text>
+      </Box>
+
+      {/* Loading / error */}
+      {loading && <Text dimColor marginTop={1}>  Loading revisions...</Text>}
+      {error && (
+        <Text color="red" marginTop={1}>
+          {" "}Error: {error}
+        </Text>
+      )}
+
+      {/* Revision list */}
+      {!loading &&
+        !error &&
+        revisions.map((rev, i) => {
+          const isActive = i === cursor;
+          const isCurrent = rev.revision === currentRevision;
+          const shortImage = rev.image.split("/").pop()?.slice(0, 40) ?? rev.image.slice(0, 40);
+          return (
+            <Box key={rev.revision} marginTop={1}>
+              <Text color={isActive ? "cyan" : undefined} bold={isActive}>
+                {isActive ? "▶ " : "  "}
+              </Text>
+              <Text
+                color={isCurrent ? "green" : isActive ? "cyan" : undefined}
+                bold={isCurrent || isActive}
+              >
+                {`#${rev.revision}`.padEnd(5)}
+              </Text>
+              <Text
+                color={isActive ? "cyan" : undefined}
+                dimColor={!isActive && !isCurrent}
+              >
+                {shortImage.padEnd(41)}
+              </Text>
+              <Text dimColor={!isActive}>{String(rev.replicas).padEnd(10)}</Text>
+              <Text dimColor>{formatAge(rev.createdAt)}</Text>
+              {isCurrent && (
+                <Text color="green" bold>
+                  {" "}← current
+                </Text>
+              )}
+            </Box>
+          );
+        })}
+
+      {!loading && !error && revisions.length === 0 && (
+        <Text dimColor marginTop={1}>
+          {" "}No revision history found. Ensure revisionHistoryLimit &gt; 0.
+        </Text>
+      )}
+    </Box>
+  );
+}

--- a/src/components/PodDetail.tsx
+++ b/src/components/PodDetail.tsx
@@ -1,6 +1,11 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import { Box, Text, useInput, useStdout } from "ink";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
 import type { V1Pod, KubeConfig } from "@kubernetes/client-node";
+import type { RestartHistory } from "../hooks/useRestartHistory.js";
+import { RestartGraph } from "./RestartGraph.js";
 import { useLogStream } from "../hooks/useLogStream.js";
 import { formatAge } from "../utils/format.js";
 import { SplitLogView } from "./SplitLogView.js";
@@ -41,9 +46,10 @@ interface PodDetailProps {
   pod: V1Pod;
   kubeConfig: KubeConfig;
   onClose: () => void;
+  restartHistory?: RestartHistory;
 }
 
-export function PodDetail({ pod, kubeConfig, onClose }: PodDetailProps) {
+export function PodDetail({ pod, kubeConfig, onClose, restartHistory }: PodDetailProps) {
   const { stdout } = useStdout();
   const namespace = pod.metadata?.namespace ?? "default";
   const podName   = pod.metadata?.name ?? "";
@@ -54,6 +60,10 @@ export function PodDetail({ pod, kubeConfig, onClose }: PodDetailProps) {
   const [scrollOffset,    setScrollOffset]    = useState(0);
   const [follow,          setFollow]          = useState(true);
   const [splitMode,       setSplitMode]       = useState(false);
+  const [showRestartGraph, setShowRestartGraph] = useState(false);
+
+  // ── Export state ───────────────────────────────────────────────────────────
+  const [exportMsg, setExportMsg] = useState<string | null>(null);
 
   // ── Log filter / display state ─────────────────────────────────────────────
   const [logLevel,       setLogLevel]       = useState<LogLevel>("ALL");
@@ -73,6 +83,24 @@ export function PodDetail({ pod, kubeConfig, onClose }: PodDetailProps) {
   const sinceSeconds = sinceOption !== undefined ? sinceOption * 60 : undefined;
 
   const containerName = containers[activeContainer]?.name ?? "";
+
+  // ── #18: Auto-enable previous logs for CrashLoopBackOff containers ─────────
+  const activeCs = pod.status?.containerStatuses?.find(
+    (s) => s.name === containerName,
+  );
+  const isCrashLoop =
+    activeCs?.state?.waiting?.reason === "CrashLoopBackOff";
+
+  useEffect(() => {
+    if (isCrashLoop) {
+      setShowPrevious(true);
+      setFollow(false);
+    } else {
+      setShowPrevious(false);
+      setFollow(true);
+    }
+    setScrollOffset(0);
+  }, [containerName, isCrashLoop]);
 
   // Chrome: title(1) + meta(1) + labels(1) + containers(capped 4) + log-header(1)
   //       + hint-row-1(1) + hint-row-2(1) + round-border(2) + 2 inner borders(2) = 14 + containers
@@ -220,6 +248,27 @@ export function PodDetail({ pod, kubeConfig, onClose }: PodDetailProps) {
         });
         setScrollOffset(0);
       }
+
+      // #10 — Export logs to file
+      if (input === "e") {
+        const dir = path.join(os.homedir(), "kube-inspector-logs");
+        const filename = `${podName}-${containerName}-${Date.now()}.log`;
+        const filepath = path.join(dir, filename);
+        const content = displayLines.map((d) => d.display).join("\n");
+        fs.mkdir(dir, { recursive: true })
+          .then(() => fs.writeFile(filepath, content, "utf-8"))
+          .then(() => {
+            setExportMsg(`Exported → ${filepath}`);
+            setTimeout(() => setExportMsg(null), 4000);
+          })
+          .catch((err) => {
+            setExportMsg(`Export failed: ${String(err)}`);
+            setTimeout(() => setExportMsg(null), 4000);
+          });
+      }
+
+      // #5 — Restart history graph
+      if (input === "h") setShowRestartGraph((v) => !v);
     }
   });
 
@@ -301,22 +350,60 @@ export function PodDetail({ pod, kubeConfig, onClose }: PodDetailProps) {
     badges.push(<Text key="re" color="yellow" dimColor> [RE]</Text>);
 
   // ── JSX ───────────────────────────────────────────────────────────────────
+
+  // Show restart graph overlay
+  if (showRestartGraph && restartHistory) {
+    return (
+      <RestartGraph
+        pod={pod}
+        history={restartHistory}
+        onClose={() => setShowRestartGraph(false)}
+      />
+    );
+  }
+
   return (
-    <Box flexDirection="column" borderStyle="round" borderColor="cyan" flexGrow={1}>
+    <Box flexDirection="column" borderStyle="round" borderColor={isCrashLoop ? "red" : "cyan"} flexGrow={1}>
       {/* Title bar */}
       <Box justifyContent="space-between" paddingX={1}>
         <Box>
-          <Text bold color="cyan">Pod: </Text>
+          <Text bold color={isCrashLoop ? "red" : "cyan"}>Pod: </Text>
           <Text bold>{podName}</Text>
           <Text dimColor> ns: {namespace}</Text>
+          {isCrashLoop && (
+            <Text color="red" bold> ⚠ CRASHLOOP</Text>
+          )}
         </Box>
         <Box>
           {containers.length > 1 && (
             <Text dimColor>[m] {splitMode ? "single" : "split"} logs </Text>
           )}
-          <Text dimColor>[esc] close</Text>
+          <Text dimColor>[h] history  [e] export  [esc] close</Text>
         </Box>
       </Box>
+
+      {/* #18 Crash detail banner */}
+      {isCrashLoop && activeCs?.lastState?.terminated && (() => {
+        const t = activeCs.lastState.terminated;
+        return (
+          <Box paddingX={1} borderStyle="single" borderTop={false} borderLeft={false} borderRight={false} borderBottom={true}>
+            <Text color="red" bold>Last crash: </Text>
+            <Text color="yellow">exit {t.exitCode ?? "?"} </Text>
+            {t.reason && <Text color="yellow">{t.reason} </Text>}
+            {t.message && <Text dimColor>{t.message.slice(0, 60)} </Text>}
+            {t.finishedAt && <Text dimColor>finished {formatAge(t.finishedAt)} ago</Text>}
+          </Box>
+        );
+      })()}
+
+      {/* Export confirmation */}
+      {exportMsg && (
+        <Box paddingX={1}>
+          <Text color={exportMsg.startsWith("Export failed") ? "red" : "green"}>
+            {exportMsg}
+          </Text>
+        </Box>
+      )}
 
       {/* Metadata row */}
       <Box paddingX={1} borderStyle="single" borderTop={false} borderLeft={false} borderRight={false} borderBottom={true}>
@@ -441,7 +528,7 @@ export function PodDetail({ pod, kubeConfig, onClose }: PodDetailProps) {
               [↑↓][g/G] Scroll  [f] Follow  [/] Search  [r] Regex({regexMode ? "ON" : "off"})  [l] Level({logLevel})  [Esc] Close
             </Text>
             <Text dimColor>
-              [t] Timestamps({showTimestamps ? "ON" : "off"})  [w] Wrap({wrapLines ? "ON" : "off"})  [s] Since({sinceOption !== undefined ? `${sinceOption}m` : "all"})  [p] Prev({showPrevious ? "ON" : "off"})  [+/-] Tail({tailLines})
+              [t] Timestamps({showTimestamps ? "ON" : "off"})  [w] Wrap({wrapLines ? "ON" : "off"})  [s] Since({sinceOption !== undefined ? `${sinceOption}m` : "all"})  [p] Prev({showPrevious ? "ON" : "off"})  [+/-] Tail({tailLines})  [e] Export  [h] Restarts
               {containers.length > 1 ? "  [[] []] Ctr" : ""}
             </Text>
           </Box>

--- a/src/components/ResourceTable.tsx
+++ b/src/components/ResourceTable.tsx
@@ -126,6 +126,8 @@ export function ResourceTable({
   onActivate,
   selectedUids,
   onToggleSelect,
+  favouriteUids,
+  onToggleFavourite,
   maxHeight,
   mutationsEnabled,
   loading,
@@ -240,6 +242,10 @@ export function ResourceTable({
     }
     if (input === " " && filteredRows[safeLocal] && onToggleSelect) {
       onToggleSelect(filteredRows[safeLocal]);
+      return;
+    }
+    if (input === "*" && filteredRows[safeLocal] && onToggleFavourite) {
+      onToggleFavourite(filteredRows[safeLocal]);
       return;
     }
     if (key.upArrow) moveUp();
@@ -365,9 +371,14 @@ export function ResourceTable({
         const isSelected = absoluteIndex === safeLocal;
         const isEven = absoluteIndex % 2 === 0;
         const isChecked = selectedUids?.has(row.uid) ?? false;
+        const isFavourite = favouriteUids?.has(row.uid) ?? false;
 
         return (
           <Box key={row.uid} paddingX={1}>
+            {/* Favourite star */}
+            <Text color={isFavourite ? "yellow" : "gray"}>
+              {isFavourite ? "★" : " "}
+            </Text>
             {/* Checkbox */}
             <Text
               color={isChecked ? "magenta" : isSelected ? "cyan" : "gray"}
@@ -473,7 +484,7 @@ export function ResourceTable({
           {selectedUids && selectedUids.size > 1
             ? `  ${selectedUids.size} selected → enter`
             : ""}{" "}
-          / search
+          / search  * favourite
           {mutationsEnabled
             ? "  d delete  R restart  s scale  D force-del"
             : "  (read-only)"}

--- a/src/components/RestartGraph.tsx
+++ b/src/components/RestartGraph.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { Box, Text, useInput } from "ink";
+import type { V1Pod } from "@kubernetes/client-node";
+import type { RestartHistory } from "../hooks/useRestartHistory.js";
+import { formatAge } from "../utils/format.js";
+
+const SPARK_CHARS = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];
+
+function sparkline(counts: number[]): string {
+  if (counts.length === 0) return "no data";
+  const max = Math.max(...counts, 1);
+  return counts
+    .map((c) => SPARK_CHARS[Math.min(7, Math.floor((c / max) * 7))])
+    .join("");
+}
+
+interface RestartGraphProps {
+  pod: V1Pod;
+  history: RestartHistory;
+  onClose: () => void;
+}
+
+export function RestartGraph({ pod, history, onClose }: RestartGraphProps) {
+  useInput((_input, key) => {
+    if (key.escape) onClose();
+  });
+
+  const uid = pod.metadata?.uid ?? "";
+  const podHistory = history.get(uid) ?? new Map<string, { ts: number; count: number }[]>();
+  const containers = pod.spec?.containers ?? [];
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="cyan"
+      padding={1}
+    >
+      <Box justifyContent="space-between">
+        <Text bold color="cyan">
+          Restart History — {pod.metadata?.name}
+        </Text>
+        <Text dimColor>[Esc] close</Text>
+      </Box>
+
+      <Box
+        marginTop={1}
+        borderStyle="single"
+        borderTop={false}
+        borderLeft={false}
+        borderRight={false}
+        borderBottom={true}
+      >
+        <Text bold color="cyan">
+          {"  CONTAINER             RESTARTS  SPARKLINE (session)   LAST EXIT"}
+        </Text>
+      </Box>
+
+      {containers.map((c) => {
+        const cs = pod.status?.containerStatuses?.find((s) => s.name === c.name);
+        const restarts = cs?.restartCount ?? 0;
+        const snapshots = podHistory.get(c.name) ?? [];
+        const spark = sparkline(snapshots.map((s) => s.count));
+        const last = cs?.lastState?.terminated;
+        const exitInfo = last
+          ? `exit:${last.exitCode ?? "?"} ${last.reason ?? ""} ${
+              last.finishedAt ? formatAge(last.finishedAt) + " ago" : ""
+            }`
+          : "—";
+        const isCrash =
+          cs?.state?.waiting?.reason === "CrashLoopBackOff";
+
+        return (
+          <Box key={c.name} marginTop={1} flexDirection="column">
+            <Box>
+              <Text color={isCrash ? "red" : restarts > 0 ? "yellow" : "green"}>
+                {isCrash ? "⚠ " : "  "}
+              </Text>
+              <Text bold={isCrash} color={isCrash ? "red" : undefined}>
+                {c.name.padEnd(22)}
+              </Text>
+              <Text
+                color={
+                  restarts > 10 ? "red" : restarts > 3 ? "yellow" : "green"
+                }
+                bold={restarts > 0}
+              >
+                {String(restarts).padEnd(10)}
+              </Text>
+              <Text color="cyan">{spark.padEnd(22)}</Text>
+              <Text dimColor>{exitInfo}</Text>
+            </Box>
+            {last && (
+              <Box>
+                <Text dimColor>
+                  {"    "}Started:{" "}
+                  {last.startedAt
+                    ? new Date(last.startedAt).toISOString()
+                    : "—"}
+                  {"  "}Finished:{" "}
+                  {last.finishedAt
+                    ? new Date(last.finishedAt).toISOString()
+                    : "—"}
+                </Text>
+              </Box>
+            )}
+          </Box>
+        );
+      })}
+
+      {containers.length === 0 && (
+        <Text dimColor marginTop={1}>
+          No container data available.
+        </Text>
+      )}
+
+      <Box marginTop={1}>
+        <Text dimColor>
+          Sparkline shows restart counts sampled every 15s during this session.
+          Each bar represents one recorded change.
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/hooks/useFavourites.ts
+++ b/src/hooks/useFavourites.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect } from "react";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+
+const FAVOURITES_PATH = path.join(
+  os.homedir(),
+  ".kube-inspector",
+  "favourites.json",
+);
+
+export function useFavourites() {
+  const [favourites, setFavourites] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    fs.readFile(FAVOURITES_PATH, "utf-8")
+      .then((data) => {
+        const arr = JSON.parse(data) as string[];
+        setFavourites(new Set(arr));
+      })
+      .catch(() => {}); // file doesn't exist yet — that's fine
+  }, []);
+
+  function toggle(uid: string) {
+    setFavourites((prev) => {
+      const next = new Set(prev);
+      if (next.has(uid)) next.delete(uid);
+      else next.add(uid);
+      const arr = Array.from(next);
+      fs.mkdir(path.dirname(FAVOURITES_PATH), { recursive: true })
+        .then(() =>
+          fs.writeFile(FAVOURITES_PATH, JSON.stringify(arr), "utf-8"),
+        )
+        .catch(() => {});
+      return next;
+    });
+  }
+
+  return { favourites, toggle };
+}

--- a/src/hooks/useRestartHistory.ts
+++ b/src/hooks/useRestartHistory.ts
@@ -1,0 +1,61 @@
+import { useState, useEffect, useRef } from "react";
+import type { V1Pod } from "@kubernetes/client-node";
+
+export interface RestartSnapshot {
+  ts: number; // epoch ms
+  count: number;
+}
+
+/** Per-pod, per-container restart history recorded during this session. */
+export type RestartHistory = Map<string, Map<string, RestartSnapshot[]>>;
+
+const MAX_SNAPSHOTS = 30;
+const SNAPSHOT_INTERVAL_MS = 15_000;
+
+/**
+ * Watches the pod map and records restart-count snapshots every interval.
+ * Returns a stable ref so consumers can look up history without re-renders.
+ */
+export function useRestartHistory(pods: Map<string, V1Pod>): RestartHistory {
+  const historyRef = useRef<RestartHistory>(new Map());
+  const [, forceRender] = useState(0);
+
+  function snapshot() {
+    pods.forEach((pod) => {
+      const uid = pod.metadata?.uid;
+      if (!uid) return;
+      if (!historyRef.current.has(uid))
+        historyRef.current.set(uid, new Map());
+      const podHistory = historyRef.current.get(uid)!;
+
+      for (const cs of pod.status?.containerStatuses ?? []) {
+        const name = cs.name;
+        if (!podHistory.has(name)) podHistory.set(name, []);
+        const snapshots = podHistory.get(name)!;
+        const count = cs.restartCount ?? 0;
+        const last = snapshots[snapshots.length - 1];
+        // Only record if count changed or first snapshot
+        if (!last || last.count !== count) {
+          snapshots.push({ ts: Date.now(), count });
+          if (snapshots.length > MAX_SNAPSHOTS) snapshots.shift();
+        }
+      }
+    });
+  }
+
+  // Record immediately when pod data arrives
+  useEffect(() => {
+    snapshot();
+  }, [pods]);
+
+  // Also record on a fixed interval to capture slow-drift restarts
+  useEffect(() => {
+    const id = setInterval(() => {
+      snapshot();
+      forceRender((n) => n + 1);
+    }, SNAPSHOT_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [pods]);
+
+  return historyRef.current;
+}

--- a/src/utils/mutate.ts
+++ b/src/utils/mutate.ts
@@ -9,6 +9,7 @@ export enum MutationAction {
   RestartDeployment = "RestartDeployment",
   ScaleDeployment = "ScaleDeployment",
   ForceDeletePod = "ForceDeletePod",
+  RollbackDeployment = "RollbackDeployment",
 }
 
 const IMMUTABLE_NAMESPACES = new Set(["kube-system"]);
@@ -34,6 +35,14 @@ export type MutateParams =
       namespace: string;
       replicas: number;
       maxReplicas?: number;
+    }
+  | {
+      action: MutationAction.RollbackDeployment;
+      name: string;
+      namespace: string;
+      /** Pod template spec from the target ReplicaSet to restore */
+      templateSpec: Record<string, unknown>;
+      revision: number;
     };
 
 async function appendAudit(entry: Record<string, unknown>): Promise<void> {
@@ -99,6 +108,19 @@ export async function mutate(client: any, params: MutateParams): Promise<void> {
               },
             },
           },
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { headers: { "Content-Type": "application/merge-patch+json" } },
+        );
+        break;
+      }
+      case MutationAction.RollbackDeployment: {
+        await client.patchNamespacedDeployment(
+          params.name,
+          params.namespace,
+          { spec: { template: { spec: params.templateSpec } } },
           undefined,
           undefined,
           undefined,


### PR DESCRIPTION
…ment rollout

Implements issues #8, #5, #18, #10, and #14.

- feat(favourites): pin resources with [*] (#8) useFavourites hook persists to ~/.kube-inspector/favourites.json. Pinned rows float to the top with a ★ indicator. Works across all tabs (pods, deployments, services, PVCs).

- feat(restarts): in-session restart history graph via [h] (#5) useRestartHistory snapshots restart counts every 15s. RestartGraph overlay shows ASCII sparkline (▁–█) per container plus last exit code, reason, and termination timestamps.

- feat(crash): CrashLoopBackOff drill-down (#18) PodDetail auto-enables previous-log mode and surfaces the last terminated container state (exit code, reason, message, timestamp) in a red banner when a container is in CrashLoopBackOff.

- feat(logs): export current log view to file with [e] (#10) Writes filtered/visible log lines to ~/kube-inspector-logs/<pod>-<container>-<ts>.log and shows a confirmation banner for 4s.

- feat(deployments): rollout history and rollback via [Enter] (#14) DeploymentDetail overlay fetches ReplicaSets, lists revisions with image and age, and lets you rollback to any revision with [r]. Rollback goes through the existing ConfirmModal + audit log.