### PR TITLE
Fix build config, reapply lost fixes, add CI and npm publish prep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check (src + tests)
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,12 @@
   "description": "A Node.js TUI for inspecting and monitoring Kubernetes clusters in real-time — pods, deployments, services, nodes, and more, live in your terminal.",
   "type": "module",
   "main": "dist/index.js",
+  "bin": {
+    "kube-inspector": "dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
   "engines": {
     "node": ">=20"
   },
@@ -21,7 +27,9 @@
   "homepage": "https://github.com/ajaxecho3/kube-inspector#readme",
   "scripts": {
     "start": "node --no-deprecation --import tsx/esm src/index.tsx",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
+    "postbuild": "chmod +x dist/index.js",
+    "typecheck": "tsc -p tsconfig.json",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -609,11 +609,7 @@ export function App({ mutationsEnabled, maxReplicas }: AppProps) {
             deployment={detailDeployment}
             kubeConfig={kubeClient.kubeConfig}
             onClose={() => setDetailDeployment(null)}
-            onRollback={(deploy, revision) => {
-              const rs = Array.from(deployments.resources.values()).find(
-                (d) => d.metadata?.uid === deploy.metadata?.uid,
-              );
-              if (!rs) return;
+            onRollback={(deploy, revision, replicaSet) => {
               const name = deploy.metadata?.name ?? "";
               const ns = deploy.metadata?.namespace ?? "";
               setPendingMutation({
@@ -625,7 +621,10 @@ export function App({ mutationsEnabled, maxReplicas }: AppProps) {
                     action: MutationAction.RollbackDeployment,
                     name,
                     namespace: ns,
-                    templateSpec: deploy.spec?.template?.spec as Record<string, unknown>,
+                    // The target revision's own ReplicaSet template — NOT the
+                    // current deployment's template, which is what's being
+                    // rolled back *from*.
+                    templateSpec: replicaSet.spec?.template?.spec as unknown as Record<string, unknown>,
                     revision,
                   }),
               });

--- a/src/components/DeploymentDetail.tsx
+++ b/src/components/DeploymentDetail.tsx
@@ -16,7 +16,10 @@ interface DeploymentDetailProps {
   deployment: V1Deployment;
   kubeConfig: KubeConfig;
   onClose: () => void;
-  onRollback?: (deployment: V1Deployment, revision: number) => void;
+  /** `replicaSet` is the target revision's ReplicaSet — its pod template is
+   * what actually gets restored on rollback (the current deployment's own
+   * template is the thing being rolled back *from*, not the target). */
+  onRollback?: (deployment: V1Deployment, revision: number, replicaSet: V1ReplicaSet) => void;
 }
 
 export function DeploymentDetail({
@@ -45,16 +48,12 @@ export function DeploymentDetail({
           .map(([k, v]) => `${k}=${v}`)
           .join(",");
 
-        const res = await appsV1.listNamespacedReplicaSet(
+        const res = await appsV1.listNamespacedReplicaSet({
           namespace,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
           labelSelector,
-        );
+        });
 
-        const rsList = (res.body?.items ?? []) as V1ReplicaSet[];
+        const rsList = (res.items ?? []) as V1ReplicaSet[];
         const parsed: Revision[] = rsList
           .map((rs) => {
             const rev = Number(
@@ -92,7 +91,7 @@ export function DeploymentDetail({
     if (key.downArrow) setCursor((i) => Math.min(revisions.length - 1, i + 1));
     if ((input === "r" || key.return) && revisions[cursor]) {
       const rev = revisions[cursor];
-      if (rev.revision !== currentRevision) onRollback?.(deployment, rev.revision);
+      if (rev.revision !== currentRevision) onRollback?.(deployment, rev.revision, rev.rs);
     }
   });
 
@@ -143,11 +142,15 @@ export function DeploymentDetail({
       </Box>
 
       {/* Loading / error */}
-      {loading && <Text dimColor marginTop={1}>  Loading revisions...</Text>}
+      {loading && (
+        <Box marginTop={1}>
+          <Text dimColor>  Loading revisions...</Text>
+        </Box>
+      )}
       {error && (
-        <Text color="red" marginTop={1}>
-          {" "}Error: {error}
-        </Text>
+        <Box marginTop={1}>
+          <Text color="red"> Error: {error}</Text>
+        </Box>
       )}
 
       {/* Revision list */}
@@ -186,9 +189,9 @@ export function DeploymentDetail({
         })}
 
       {!loading && !error && revisions.length === 0 && (
-        <Text dimColor marginTop={1}>
-          {" "}No revision history found. Ensure revisionHistoryLimit &gt; 0.
-        </Text>
+        <Box marginTop={1}>
+          <Text dimColor> No revision history found. Ensure revisionHistoryLimit &gt; 0.</Text>
+        </Box>
       )}
     </Box>
   );

--- a/src/components/RestartGraph.tsx
+++ b/src/components/RestartGraph.tsx
@@ -100,9 +100,9 @@ export function RestartGraph({ pod, history, onClose }: RestartGraphProps) {
       })}
 
       {containers.length === 0 && (
-        <Text dimColor marginTop={1}>
-          No container data available.
-        </Text>
+        <Box marginTop={1}>
+          <Text dimColor>No container data available.</Text>
+        </Box>
       )}
 
       <Box marginTop={1}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import React from "react";
 import { render } from "ink";
 import { App } from "./App.js";

--- a/src/utils/mutate.ts
+++ b/src/utils/mutate.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { setHeaderOptions } from "@kubernetes/client-node";
 
 export enum MutationAction {
   DeletePod = "DeletePod",
@@ -74,71 +75,86 @@ export async function mutate(client: any, params: MutateParams): Promise<void> {
     namespace: params.namespace,
   };
 
+  // The installed @kubernetes/client-node version only exposes the
+  // object-param calling convention (e.g. `deleteNamespacedPod({ name,
+  // namespace })`) — every call below must use that shape, not the old
+  // positional-argument style. Patch calls also need this: by default the
+  // generated client negotiates a JSON-Patch content type for `patch*`
+  // methods, which would misinterpret our plain merge-patch-shaped body as a
+  // JSON-Patch operation array. `setHeaderOptions` forces the Content-Type
+  // header via a middleware that runs after the request is built, so the
+  // (identically-serialized) JSON body gets read as a merge patch instead.
+  const mergePatchOptions = setHeaderOptions(
+    "Content-Type",
+    "application/merge-patch+json",
+  );
+
   try {
     switch (params.action) {
       case MutationAction.DeletePod:
-        await client.deleteNamespacedPod(params.name, params.namespace);
+        await client.deleteNamespacedPod({
+          name: params.name,
+          namespace: params.namespace,
+        });
         break;
       case MutationAction.ForceDeletePod:
-        await client.deleteNamespacedPod(
-          params.name,
-          params.namespace,
-          undefined,
-          undefined,
-          0,
-        );
+        await client.deleteNamespacedPod({
+          name: params.name,
+          namespace: params.namespace,
+          gracePeriodSeconds: 0,
+        });
         break;
       case MutationAction.DeleteDeployment:
-        await client.deleteNamespacedDeployment(params.name, params.namespace);
+        await client.deleteNamespacedDeployment({
+          name: params.name,
+          namespace: params.namespace,
+        });
         break;
       case MutationAction.DeleteService:
-        await client.deleteNamespacedService(params.name, params.namespace);
+        await client.deleteNamespacedService({
+          name: params.name,
+          namespace: params.namespace,
+        });
         break;
       case MutationAction.RestartDeployment: {
         const now = new Date().toISOString();
         await client.patchNamespacedDeployment(
-          params.name,
-          params.namespace,
           {
-            spec: {
-              template: {
-                metadata: {
-                  annotations: { "kubectl.kubernetes.io/restartedAt": now },
+            name: params.name,
+            namespace: params.namespace,
+            body: {
+              spec: {
+                template: {
+                  metadata: {
+                    annotations: { "kubectl.kubernetes.io/restartedAt": now },
+                  },
                 },
               },
             },
           },
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          { headers: { "Content-Type": "application/merge-patch+json" } },
+          mergePatchOptions,
         );
         break;
       }
       case MutationAction.RollbackDeployment: {
         await client.patchNamespacedDeployment(
-          params.name,
-          params.namespace,
-          { spec: { template: { spec: params.templateSpec } } },
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          { headers: { "Content-Type": "application/merge-patch+json" } },
+          {
+            name: params.name,
+            namespace: params.namespace,
+            body: { spec: { template: { spec: params.templateSpec } } },
+          },
+          mergePatchOptions,
         );
         break;
       }
       case MutationAction.ScaleDeployment:
         await client.patchNamespacedDeploymentScale(
-          params.name,
-          params.namespace,
-          { spec: { replicas: params.replicas } },
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          { headers: { "Content-Type": "application/merge-patch+json" } },
+          {
+            name: params.name,
+            namespace: params.namespace,
+            body: { spec: { replicas: params.replicas } },
+          },
+          mergePatchOptions,
         );
         break;
     }

--- a/tests/components/AlertBanner.test.tsx
+++ b/tests/components/AlertBanner.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { describe, it, expect } from "vitest";
 import { render } from "ink-testing-library";
-import { AlertBanner } from "../../src/components/AlertBanner";
+import { AlertBanner } from "../../src/components/AlertBanner.js";
 
 describe("AlertBanner", () => {
   it("renders the alert message", () => {

--- a/tests/components/ConfirmModal.test.tsx
+++ b/tests/components/ConfirmModal.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render } from "ink-testing-library";
-import { ConfirmModal } from "../../src/components/ConfirmModal";
+import { ConfirmModal } from "../../src/components/ConfirmModal.js";
 
 describe("ConfirmModal", () => {
   it("renders the action description", () => {

--- a/tests/components/NavTabs.test.tsx
+++ b/tests/components/NavTabs.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { describe, it, expect } from "vitest";
 import { render } from "ink-testing-library";
-import { NavTabs, TAB_LABELS } from "../../src/components/NavTabs";
+import { NavTabs, TAB_LABELS } from "../../src/components/NavTabs.js";
 
 describe("NavTabs", () => {
   it("renders all tab labels", () => {
@@ -22,7 +22,7 @@ describe("NavTabs", () => {
   });
 
   it("shows resource count when tabSummaries provided", () => {
-    const summaries = TAB_LABELS.map((_, i) => ({ total: i + 1, critical: 0 }));
+    const summaries = TAB_LABELS.map((_: string, i: number) => ({ total: i + 1, critical: 0 }));
     const { lastFrame } = render(
       <NavTabs activeTab={0} onTabChange={() => {}} tabSummaries={summaries} />,
     );

--- a/tests/components/StatusBadge.test.tsx
+++ b/tests/components/StatusBadge.test.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { describe, it, expect } from "vitest";
 import { render } from "ink-testing-library";
-import { StatusBadge } from "../../src/components/StatusBadge";
-import { HealthStatus } from "../../src/utils/health";
+import { StatusBadge } from "../../src/components/StatusBadge.js";
+import { HealthStatus } from "../../src/utils/health.js";
 
 describe("StatusBadge", () => {
   it("renders a dot for healthy status", () => {

--- a/tests/components/UsageGraph.test.tsx
+++ b/tests/components/UsageGraph.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { describe, it, expect } from "vitest";
 import { render } from "ink-testing-library";
-import { UsageGraph, bucketValues, buildAxisLine } from "../../src/components/UsageGraph";
+import { UsageGraph, bucketValues, buildAxisLine } from "../../src/components/UsageGraph.js";
 import type { V1Pod } from "@kubernetes/client-node";
 
 function makePod(cpuRequest?: string, memRequest?: string): V1Pod {

--- a/tests/utils/format.test.ts
+++ b/tests/utils/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { formatAge } from "../../src/utils/format";
+import { formatAge } from "../../src/utils/format.js";
 
 describe("formatAge", () => {
   beforeEach(() => {

--- a/tests/utils/health.test.ts
+++ b/tests/utils/health.test.ts
@@ -4,7 +4,7 @@ import {
   deploymentHealth,
   nodeHealth,
   HealthStatus,
-} from "../../src/utils/health";
+} from "../../src/utils/health.js";
 
 describe("podHealth", () => {
   it("returns healthy for Running phase", () => {

--- a/tests/utils/metrics.test.ts
+++ b/tests/utils/metrics.test.ts
@@ -7,7 +7,7 @@ import {
   usageColor,
   brighten,
   usageSpark,
-} from "../../src/utils/metrics";
+} from "../../src/utils/metrics.js";
 
 describe("parseCpuToMillicores", () => {
   it("parses nanocores", () => {

--- a/tests/utils/mutate.test.ts
+++ b/tests/utils/mutate.test.ts
@@ -27,10 +27,10 @@ describe("mutate", () => {
       namespace: "staging",
     });
 
-    expect(mockClient.deleteNamespacedPod).toHaveBeenCalledWith(
-      "bad-pod",
-      "staging",
-    );
+    expect(mockClient.deleteNamespacedPod).toHaveBeenCalledWith({
+      name: "bad-pod",
+      namespace: "staging",
+    });
     expect(appendFile).toHaveBeenCalled();
     const auditEntry = (appendFile as any).mock.calls[0][1] as string;
     expect(auditEntry).toContain("bad-pod");
@@ -78,6 +78,129 @@ describe("mutate", () => {
     ).rejects.toThrow("exceeds maximum");
 
     expect(mockClient.patchNamespacedDeploymentScale).not.toHaveBeenCalled();
+  });
+
+  it("force-deletes a pod with gracePeriodSeconds: 0, object-param style", async () => {
+    const { mutate, MutationAction } =
+      await import("../../src/utils/mutate.js");
+
+    const mockClient = {
+      deleteNamespacedPod: vi.fn().mockResolvedValue({}),
+    } as any;
+
+    await mutate(mockClient, {
+      action: MutationAction.ForceDeletePod,
+      name: "stuck-pod",
+      namespace: "staging",
+    });
+
+    expect(mockClient.deleteNamespacedPod).toHaveBeenCalledWith({
+      name: "stuck-pod",
+      namespace: "staging",
+      gracePeriodSeconds: 0,
+    });
+  });
+
+  it("deletes a deployment and a service with object-param style", async () => {
+    const { mutate, MutationAction } =
+      await import("../../src/utils/mutate.js");
+
+    const mockDeploy = { deleteNamespacedDeployment: vi.fn().mockResolvedValue({}) } as any;
+    await mutate(mockDeploy, {
+      action: MutationAction.DeleteDeployment,
+      name: "api",
+      namespace: "default",
+    });
+    expect(mockDeploy.deleteNamespacedDeployment).toHaveBeenCalledWith({
+      name: "api",
+      namespace: "default",
+    });
+
+    const mockSvc = { deleteNamespacedService: vi.fn().mockResolvedValue({}) } as any;
+    await mutate(mockSvc, {
+      action: MutationAction.DeleteService,
+      name: "api-svc",
+      namespace: "default",
+    });
+    expect(mockSvc.deleteNamespacedService).toHaveBeenCalledWith({
+      name: "api-svc",
+      namespace: "default",
+    });
+  });
+
+  it("restarts a deployment via a merge-patch, object-param style", async () => {
+    const { mutate, MutationAction } =
+      await import("../../src/utils/mutate.js");
+
+    const mockClient = {
+      patchNamespacedDeployment: vi.fn().mockResolvedValue({}),
+    } as any;
+
+    await mutate(mockClient, {
+      action: MutationAction.RestartDeployment,
+      name: "api",
+      namespace: "default",
+    });
+
+    expect(mockClient.patchNamespacedDeployment).toHaveBeenCalledTimes(1);
+    const [param, options] = mockClient.patchNamespacedDeployment.mock.calls[0];
+    expect(param.name).toBe("api");
+    expect(param.namespace).toBe("default");
+    expect(param.body.spec.template.metadata.annotations).toHaveProperty(
+      "kubectl.kubernetes.io/restartedAt",
+    );
+    // Forces merge-patch semantics rather than the client's default
+    // (JSON-Patch) content-type negotiation — see mutate.ts for why.
+    expect(options.middlewareMergeStrategy).toBe("append");
+    expect(options.middleware).toHaveLength(1);
+  });
+
+  it("rolls back a deployment to the target revision's template, object-param style", async () => {
+    const { mutate, MutationAction } =
+      await import("../../src/utils/mutate.js");
+
+    const mockClient = {
+      patchNamespacedDeployment: vi.fn().mockResolvedValue({}),
+    } as any;
+
+    const templateSpec = { containers: [{ name: "app", image: "app:v1" }] };
+    await mutate(mockClient, {
+      action: MutationAction.RollbackDeployment,
+      name: "api",
+      namespace: "default",
+      templateSpec,
+      revision: 3,
+    });
+
+    const [param] = mockClient.patchNamespacedDeployment.mock.calls[0];
+    expect(param).toEqual({
+      name: "api",
+      namespace: "default",
+      body: { spec: { template: { spec: templateSpec } } },
+    });
+  });
+
+  it("scales a deployment via object-param style", async () => {
+    const { mutate, MutationAction } =
+      await import("../../src/utils/mutate.js");
+
+    const mockClient = {
+      patchNamespacedDeploymentScale: vi.fn().mockResolvedValue({}),
+    } as any;
+
+    await mutate(mockClient, {
+      action: MutationAction.ScaleDeployment,
+      name: "api",
+      namespace: "default",
+      replicas: 5,
+    });
+
+    const [param] = mockClient.patchNamespacedDeploymentScale.mock.calls[0];
+    expect(param).toEqual({
+      name: "api",
+      namespace: "default",
+      body: { spec: { replicas: 5 } },
+    });
   });
 
   it("rejects mutations on kube-system namespace without calling k8s", async () => {

--- a/tests/utils/sparkline.test.ts
+++ b/tests/utils/sparkline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { sparkline, charForRatio } from "../../src/utils/sparkline";
+import { sparkline, charForRatio } from "../../src/utils/sparkline.js";
 
 describe("sparkline", () => {
   it("returns a placeholder for an empty series", () => {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,13 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "jsx": "react-jsx",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "outDir": "dist",
-    "rootDir": "src"
+    "noEmit": true
   },
   "include": [
     "src",


### PR DESCRIPTION
- Split tsconfig into a noEmit type-check config and a build-only config (tsconfig.build.json) to fix TS6059 rootDir conflict
- Fix missing .js extensions and implicit-any in test files
- Bump target to ES2022 for Array/String.at() type support
- Reapply mutate.ts, DeploymentDetail.tsx, RestartGraph.tsx and App.tsx fixes lost in an earlier branch reset
- Add GitHub Actions CI workflow (Node 20 & 22 matrix)
- Add npm publish prep: shebang + bin field, files field, postbuild chmod, manually-triggered publish workflow (package stays private and unpublished until explicitly requested)